### PR TITLE
working Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,6 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    - PYTHON: "C:\\Miniconda2"
-      CONDA_PY: "27"
-    - PYTHON: "C:\\Miniconda2-x64"
-      CONDA_PY: "27"
-      ARCH: "64"
     - PYTHON: "C:\\Miniconda3"
       CONDA_PY: "27"
     - PYTHON: "C:\\Miniconda3-x64"
@@ -40,10 +35,14 @@ install:
   - conda config --add channels omnia
   - conda update -yq --all
   - conda install -yq conda-build jinja2
+  - conda install python=%CONDA_PY:~0,1%.%CONDA_PY:~1,2% -y
+#  - python -E -V
+  - conda build --quiet develop\\conda-recipe
+  - conda install --use-local mdsrv -y
+
 
 build: false
 
-test_script:
-  - "%CMD_IN_ENV% conda build --quiet develop\\conda-recipe"
-  - "%CMD_IN_ENV% conda install --use-local mdsrv -y"
-  - "%CMD_IN_ENV% mdsrv -h
+
+test_script:  
+  - "%CMD_IN_ENV% mdsrv -h"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+# mainly from MDTraj appveyor
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
@@ -7,20 +8,32 @@ environment:
     PYTHONUNBUFFERED: 1
 
   matrix:
-    - PYTHON: "C:\\Miniconda3"
-      CONDA_PY: "35"
-      CONDA_NPY: "1.10"
+    - PYTHON: "C:\\Miniconda2"
+      CONDA_PY: "27"
+    - PYTHON: "C:\\Miniconda2-x64"
+      CONDA_PY: "27"
+      ARCH: "64"
     - PYTHON: "C:\\Miniconda3"
       CONDA_PY: "27"
-      CONDA_NPY: "1.10"
     - PYTHON: "C:\\Miniconda3-x64"
       CONDA_PY: "27"
-      CONDA_NPY: "1.10"
       ARCH: "64"
+    - PYTHON: "C:\\Miniconda3"
+      CONDA_PY: "34"
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "34"
+      ARCH: "64"
+    - PYTHON: "C:\\Miniconda3"
+      CONDA_PY: "35"
     - PYTHON: "C:\\Miniconda3-x64"
       CONDA_PY: "35"
-      CONDA_NPY: "1.10"
       ARCH: "64"
+    - PYTHON: "C:\\Miniconda3"
+      CONDA_PY: "36"
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "36"
+      ARCH: "64"
+
 
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
@@ -32,3 +45,5 @@ build: false
 
 test_script:
   - "%CMD_IN_ENV% conda build --quiet develop\\conda-recipe"
+  - "%CMD_IN_ENV% conda install --use-local mdsrv -y"
+  - "%CMD_IN_ENV% mdsrv -h

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\develop\\appveyor-ci\\run_with_env.cmd"
+    PYTHONUNBUFFERED: 1
+
+  matrix:
+    - PYTHON: "C:\\Miniconda3"
+      CONDA_PY: "35"
+      CONDA_NPY: "1.10"
+    - PYTHON: "C:\\Miniconda3"
+      CONDA_PY: "27"
+      CONDA_NPY: "1.10"
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "27"
+      CONDA_NPY: "1.10"
+      ARCH: "64"
+    - PYTHON: "C:\\Miniconda3-x64"
+      CONDA_PY: "35"
+      CONDA_NPY: "1.10"
+      ARCH: "64"
+
+install:
+  - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - conda config --add channels omnia
+  - conda update -yq --all
+  - conda install -yq conda-build jinja2
+
+build: false
+
+test_script:
+  - "%CMD_IN_ENV% conda build --quiet develop\\conda-recipe"

--- a/develop/appveyor-ci/run_with_env.cmd
+++ b/develop/appveyor-ci/run_with_env.cmd
@@ -1,0 +1,50 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+:: Modified for use with conda environment variables
+
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%CONDA_PY:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)


### PR DESCRIPTION
ADD: working appveyor for windows (32 & 64) each for python 2.7, 3.4, 3.5, 3.6 using miniconda3