### PR TITLE
MDAnalysis & MDtraj support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,41 @@
+# blocklist
+branches:
+  except:
+    - gh-pages
+
 matrix:
     include:
         - os: osx
           language: generic
+          python: "2.7"
           env: PYTHON_VERSION=2.7
         - os: osx
           language: generic
+          python: "3.4"
           env: PYTHON_VERSION=3.4
         - os: osx
           language: generic
+          python: "3.5"
           env: PYTHON_VERSION=3.5
         - os: osx
           language: generic
+          python: "3.6"
           env: PYTHON_VERSION=3.6
         - os: linux
           language: python
+          python: "2.7"
           env: PYTHON_VERSION=2.7
         - os: linux
           language: python
+          python: "3.4"
           env: PYTHON_VERSION=3.4
         - os: linux
           language: python
+          python: "3.5"
           env: PYTHON_VERSION=3.5
         - os: linux
           language: python
+          python: "3.6"
           env: PYTHON_VERSION=3.6
 
 
@@ -46,11 +59,13 @@ install:
   - hash -r
   - conda update -qy conda
   #- conda info -a
-  - conda config --add channels conda-forge
-  - conda install anaconda-client -y
-  - conda config --add channels omnia
-  - conda install conda-build -y
   - conda install python=$PYTHON_VERSION -y
+  - conda install conda-build pip -y
+  - conda install anaconda-client -y
+  #- conda list
+  #- python -E -V
+  - conda config --add channels omnia
+  - conda config --add channels conda-forge
   - conda build develop/conda-recipe
   #- python -E -V
   - conda install mdsrv --use-local -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ environment:
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - conda config --add channels omnia
+  - conda config --add channels conda-forge
   - conda update -yq --all
   - conda install -yq conda-build jinja2
   - conda install python=%CONDA_PY:~0,1%.%CONDA_PY:~1,2% -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,8 @@ environment:
     PYTHONUNBUFFERED: 1
   BINSTAR_TOKEN:
     secure: LJUoqxkUbcJR0UnL2Ap7/dLquM6cX8i1JC0mXNvwXEbTTVW3C98qQ/JlJWzAYpoy
-
+#  BINSTAR_TOKEN:
+#    secure: iG/R6JSE4NP4kGAKws0IDTnhB70bYlUI2FHnmPpH9FCOlEta6TXinmu76MSSW03W
 
   matrix:
     - PYTHON: "C:\\Miniconda3"
@@ -59,7 +60,7 @@ deploy_script:
   # because appveyor prints to stderror, we will run it in command mode by doing a check first
   - ps: If ($env:APPVEYOR_REPO_TAG -eq "true" -And $env:APPVEYOR_REPO_BRANCH -eq "master") { $env:conda_upload = 'true' } Else { write-output "Not on a tag on master, won't deploy to anaconda" }
   - cmd: IF "%conda_upload%"=="true" anaconda -t %BINSTAR_TOKEN% upload .\win-*\*.tar.bz2 -u j0kaso --no-progress --force
-
+#  - cmd: IF "%conda_upload%"=="true" anaconda -t %BINSTAR_TOKEN% upload .\win-*\*.tar.bz2 -u ngl --no-progress --force
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\develop\\appveyor-ci\\run_with_env.cmd"
     PYTHONUNBUFFERED: 1
+  BINSTAR_TOKEN:
+    secure: LJUoqxkUbcJR0UnL2Ap7/dLquM6cX8i1JC0mXNvwXEbTTVW3C98qQ/JlJWzAYpoy
+
 
   matrix:
     - PYTHON: "C:\\Miniconda3"
@@ -47,3 +50,16 @@ build: false
 
 test_script:  
   - "%CMD_IN_ENV% mdsrv -h"
+
+
+deploy_script:
+  - echo "Starting Deployment"
+  # upload conda builds to conda cloud
+  - cmd: set PATH=%PYTHON%;%PYTHON%/Scripts;%PYTHON%/Library/bin;%PATH%
+  # because appveyor prints to stderror, we will run it in command mode by doing a check first
+  - ps: If ($env:APPVEYOR_REPO_TAG -eq "true" -And $env:APPVEYOR_REPO_BRANCH -eq "master") { $env:conda_upload = 'true' } Else { write-output "Not on a tag on master, won't deploy to anaconda" }
+  - cmd: IF "%conda_upload%"=="true" anaconda -t %BINSTAR_TOKEN% upload .\win-*\*.tar.bz2 -u j0kaso --no-progress --force
+
+
+notifications:
+  email: false

--- a/develop/conda-recipe/meta.yaml
+++ b/develop/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - scipy
     - zlib
     - mdtraj
-    - mdanalysis # [not win]
+    - mdanalysis # [not win and py2k]
     - simpletraj # [not win]
 
   run:
@@ -29,7 +29,7 @@ requirements:
     - numpy
     - flask
     - mdtraj
-    - mdanalysis # [not win]
+    - mdanalysis # [not win and py2k]
     - simpletraj # [not win]
 
 test:

--- a/develop/conda-recipe/meta.yaml
+++ b/develop/conda-recipe/meta.yaml
@@ -14,13 +14,14 @@ requirements:
     - python
     - cython
     - numpy
-    - msinttypes #  [win and py2k]
+    - msinttypes # [win and py2k]
     - setuptools
     - flask
     - scipy
     - zlib
     - mdtraj
-   # - simpletraj
+    - mdanalysis # [not win]
+    - simpletraj # [not win]
 
   run:
     - python
@@ -28,7 +29,8 @@ requirements:
     - numpy
     - flask
     - mdtraj
-   # - simpletraj
+    - mdanalysis # [not win]
+    - simpletraj # [not win]
 
 test:
   imports:

--- a/develop/conda-recipe/meta.yaml
+++ b/develop/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - scipy
     - zlib
     - mdtraj
-    - simpletraj
+   # - simpletraj
 
   run:
     - python
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - flask
     - mdtraj
-    - simpletraj
+   # - simpletraj
 
 test:
   imports:

--- a/mdsrv/mdsrv.py
+++ b/mdsrv/mdsrv.py
@@ -36,6 +36,7 @@ MODULE_DIR = os.path.split( os.path.abspath( __file__ ) )[0]
 
 app = Flask(__name__)
 
+struct = []
 
 ############################
 # basic auth
@@ -153,6 +154,12 @@ def crossdomain(
 @requires_auth
 @crossdomain( origin='*' )
 def webapp( filename="index.html" ):
+    if request.args.get('struc'):
+        structurefile = request.args.get('struc').split('file://')[1]
+        path = structurefile.split('/')[0]
+        name = '/'.join(structurefile.split('/')[1:])
+        global struct
+        struct = [path, name]
     directory = os.path.join( MODULE_DIR, "webapp" )
     return send_from_directory( directory, filename )
 
@@ -263,13 +270,18 @@ def traj_frame( frame, root, filename ):
         path = os.path.join( directory, filename )
     else:
         return
+    directory_struc = get_directory( struct[0] )
+    if directory_struc:
+        struc_path = os.path.join( directory_struc, struct[1] )
+    else:
+        return
     atom_indices = request.form.get( "atomIndices" )
     if atom_indices:
         atom_indices = [
             [ int( y ) for y in x.split( "," ) ]
             for x in atom_indices.split( ";" )
         ]
-    return TRAJ_CACHE.get( path ).get_frame_string(
+    return TRAJ_CACHE.get( path, struc_path ).get_frame_string(
         frame, atom_indices=atom_indices
     )
 
@@ -283,7 +295,12 @@ def traj_numframes( root, filename ):
         path = os.path.join( directory, filename )
     else:
         return
-    return str( TRAJ_CACHE.get( path ).numframes )
+    directory_struc = get_directory( struct[0] )
+    if directory_struc:
+        struc_path = os.path.join( directory_struc, struct[1] )
+    else:
+        return
+    return str( TRAJ_CACHE.get( path, struc_path ).numframes )
 
 
 @app.route( '/traj/path/<int:index>/<root>/<path:filename>', methods=['POST'] )
@@ -295,10 +312,15 @@ def traj_path( index, root, filename ):
         path = os.path.join( directory, filename )
     else:
         return
+    directory_struc = get_directory( struct[0] )
+    if directory_struc:
+        struc_path = os.path.join( directory_struc, struct[1] )
+    else:
+        return
     frame_indices = request.form.get( "frameIndices" )
     if frame_indices:
         frame_indices = None
-    return TRAJ_CACHE.get( path ).get_path_string(
+    return TRAJ_CACHE.get( path, struc_path ).get_path_string(
         index, frame_indices=frame_indices
     )
 

--- a/mdsrv/trajectory.py
+++ b/mdsrv/trajectory.py
@@ -10,8 +10,9 @@ import collections
 import numpy as np
 import warnings
 
+import mdtraj as md
 from mdtraj.formats import *
-from simpletraj import trajectory as simpletraj_trajectory
+#from simpletraj import trajectory as simpletraj_trajectory
 
 try:
     import cPickle as pickle
@@ -45,23 +46,28 @@ def get_split_xtc( directory ):
         return sorted( [ k for k, v in split.iteritems() if v > 1 ] )
 
 
-def get_trajectory( file_name ):
+def get_trajectory( file_name, struc_path ):
     ext = os.path.splitext( file_name )[1].lower()
     types = {
-        ".xtc": simpletraj_trajectory.XtcTrajectory,
-        ".trr": simpletraj_trajectory.TrrTrajectory,
-        ".netcdf": NetcdfTrajectory,
-        ".nc": NetcdfTrajectory,
-        ".dcd": simpletraj_trajectory.DcdTrajectory,
+        ".xtc": MDTrajTrajectory, #XtcTrajectory, simpletraj_trajectory.XtcTrajectory,
+        ".trr": MDTrajTrajectory, #TrrTrajectory, simpletraj_trajectory.TrrTrajectory,
+        ".netcdf": MDTrajTrajectory, #NetcdfTrajectory,
+        ".nc": MDTrajTrajectory, #NetcdfTrajectory,
+        ".dcd": DcdTrajectory, #MDTrajTrajectory, simpletraj_trajectory.DcdTrajectory,
         ".gro": GroTrajectory,
-        ".lammpstrj": LammpsTrajectory,
-        ".h5": Hdf5Trajectory,
-        ".dtr": DtrTrajectory,
-        ".arc": ArcTrajectory,
-        ".tng": TngTrajectory,
+        ".pdb": MDTrajTrajectory,
+        ".lammpstrj": MDTrajTrajectory, #LammpsTrajectory,
+        ".gz": MDTrajTrajectory,
+        ".xyz": MDTrajTrajectory, #XyzTrajectory,
+        ".mdcrd": MDTrajTrajectory, #MdcrdTrajectory,
+        ".binpos": MDTrajTrajectory, #BinposTrajectory,
+        ".h5": MDTrajTrajectory, #Hdf5Trajectory,
+        ".dtr": DtrTrajectory, #MDTrajTrajectory,
+        ".arc": ArcTrajectory, #MDTrajTrajectory,
+        ".tng": MDTrajTrajectory, #TngTrajectory,
     }
     if ext in types:
-        return types[ ext ]( file_name )
+        return types[ ext ]( file_name, struc_path )
     else:
         raise Exception( "extension '%s' not supported" % ext )
 
@@ -72,8 +78,8 @@ class TrajectoryCache( object ):
         self.mtime = {}
         self.parts = {}
 
-    def add( self, path, pathList ):
-        self.cache[ path ] = TrajectoryCollection( pathList )
+    def add( self, path, pathList, struc_path ):
+        self.cache[ path ] = TrajectoryCollection( pathList, struc_path )
         # initial mtimes
         mtime = {}
         for partPath in pathList:
@@ -82,7 +88,7 @@ class TrajectoryCache( object ):
         # initial pathList
         self.parts[ path ] = pathList
 
-    def get( self, path ):
+    def get( self, path, struc_path ):
         stem = os.path.basename( path )
         if stem.startswith( "@" ):
             pathList = frozenset(
@@ -91,7 +97,7 @@ class TrajectoryCache( object ):
         else:
             pathList = frozenset( [ path ] )
         if path not in self.cache:
-            self.add( path, pathList )
+            self.add( path, pathList, struc_path )
         elif pathList != self.parts[ path ]:
             # print( "pathList changed, rebuilding" )
             del self.cache[ path ]
@@ -109,7 +115,7 @@ class TrajectoryCache( object ):
 
 
 class Trajectory( object ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         pass
 
     def update( self, force=False ):
@@ -165,10 +171,10 @@ class Trajectory( object ):
 
 
 class TrajectoryCollection( Trajectory ):
-    def __init__( self, parts ):
+    def __init__( self, parts, struc_path ):
         self.parts = []
         for file_name in sorted( parts ):
-            self.parts.append( get_trajectory( file_name ) )
+            self.parts.append( get_trajectory( file_name, struc_path ) )
         self.box = self.parts[ 0 ].box
         self._update_numframes()
 
@@ -196,7 +202,7 @@ class TrajectoryCollection( Trajectory ):
 
 
 class TngTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         self.tng = TNGTrajectoryFile( self.file_name )
         self.tng_traj = self.tng.read()
@@ -217,12 +223,14 @@ class TngTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.tng:
+        try:
             self.tng.close()
+        except:
+            pass
 
 
 class ArcTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         self.arc = ArcTrajectoryFile( self.file_name )
         self.arc_traj = self.arc.read()
@@ -244,12 +252,14 @@ class ArcTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.arc:
+        try:
             self.arc.close()
+        except:
+            pass
 
 
 class DtrTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         self.dtr = DTRTrajectoryFile( self.file_name )
         self.dtr_traj = self.dtr.read()
@@ -270,12 +280,14 @@ class DtrTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.dtr:
+        try:
             self.dtr.close()
+        except:
+            pass
 
 
 class Hdf5Trajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         self.hdf5 = HDF5TrajectoryFile( self.file_name )
         self.hdf5_traj = self.hdf5.read()
@@ -299,12 +311,14 @@ class Hdf5Trajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.hdf5:
+        try:
             self.hdf5.close()
+        except:
+            pass
 
 
 class LammpsTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         self.lammps = LAMMPSTrajectoryFile( self.file_name )
         self.lammps_traj = self.lammps.read()
@@ -325,12 +339,14 @@ class LammpsTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.lammps:
+        try:
             self.lammps.close()
+        except:
+            pass
 
 
 class GroTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         with GroTrajectoryFile( self.file_name, 'r' ) as fp:
             self.gro = fp.read()
@@ -352,12 +368,14 @@ class GroTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.gro:
-            del self.gro
+        try:
+            self.gro.close()
+        except:
+            pass
 
 
 class TrrTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         with TRRTrajectoryFile( self.file_name, 'r' ) as fp:
             self.trr = fp.read()
@@ -376,36 +394,40 @@ class TrrTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.trr:
-            del self.trr
+        try:
+            self.trr.close()
+        except:
+            pass
 
 
 class XtcTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
-        with XTCTrajectoryFile( self.file_name, 'r' ) as fp:
-            self.xtc = fp.read()
-        self.numatoms = len(self.xtc[0][0])
-        self.numframes = len(self.xtc[1])
+        self.xtc = XTCTrajectoryFile( self.file_name )
+        self.xtc_traj = self.xtc.read()
+        self.numatoms = len(self.xtc_traj[0][0])
+        self.numframes = len(self.xtc_traj[1])
 
         self.x = None
         self.box = np.zeros( ( 3, 3 ), dtype=np.float32 )
         self.time = 0.0
 
     def _get_frame( self, index ):
-        xyz, time, step, box = self.xtc
+        xyz, time, step, box = self.xtc_traj
         self.box = box[ index ] * 10
         self.x = xyz[ index ] * 10
         self.time = time[ index ]
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.xtc:
-            del self.xtc
+        try:
+            self.xtc.close()
+        except:
+            pass
 
 
 class NetcdfTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         # http://ambermd.org/netcdf/nctraj.pdf
         self.file_name = file_name
         self.netcdf = NetCDFTrajectoryFile( self.file_name )
@@ -430,12 +452,14 @@ class NetcdfTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.netcdf:
+        try:
             self.netcdf.close()
+        except:
+            pass
 
 
 class DcdTrajectory( Trajectory ):
-    def __init__( self, file_name ):
+    def __init__( self, file_name, struc_name ):
         self.file_name = file_name
         self.dcd = DCDTrajectoryFile( self.file_name )
         self.dcd_traj = self.dcd.read()
@@ -457,5 +481,120 @@ class DcdTrajectory( Trajectory ):
         return self.box, self.x, self.time
 
     def __del__( self ):
-        if self.dcd:
+        try:
             self.dcd.close()
+        except:
+            pass
+
+
+class MdcrdTrajectory( Trajectory ):
+    def __init__( self, file_name, struc_name ):
+        self.file_name = file_name
+        self.struc_name = struc_name
+        topology = md.load( self.struc_name ).topology
+        self.numatoms = topology.n_atoms
+        self.mdcrd = MDCRDTrajectoryFile( self.file_name, self.numatoms )
+        self.mdcrd_traj = self.mdcrd.read()
+        self.numframes = len(self.mdcrd_traj[0])
+        self.x = None
+        self.box = np.zeros( ( 3, 3 ), dtype=np.float32 )
+        self.time = 0.0
+
+    def _get_frame( self, index ):
+        xyz, cell_lengths = self.mdcrd_traj
+        try:
+            self.box[ 0, 0 ] = cell_lengths[ index ][ 0 ]
+            self.box[ 1, 1 ] = cell_lengths[ index ][ 1 ]
+            self.box[ 2, 2 ] = cell_lengths[ index ][ 2 ]
+        except: pass
+        self.x = xyz[ index ]
+        return self.box, self.x, self.time
+
+    def __del__( self ):
+        try:
+            self.mdcrd.close()
+        except:
+            pass
+
+
+class BinposTrajectory( Trajectory ):
+    def __init__( self, file_name, struc_name ):
+        self.file_name = file_name
+        self.binpos = BINPOSTrajectoryFile( self.file_name )
+        self.binpos_traj = self.binpos.read()
+        self.numatoms = len(self.binpos_traj[0][0])
+        self.numframes = len(self.binpos_traj[0])
+        self.x = None
+        self.box = np.zeros( ( 3, 3 ), dtype=np.float32 )
+        self.time = 0.0
+
+    def _get_frame( self, index ):
+        xyz = self.binpos_traj
+        self.x = xyz[index]
+        return self.box, self.x, self.time
+
+    def __del__( self ):
+        try:
+            self.binpos.close()
+        except:
+            pass
+
+
+class XyzTrajectory( Trajectory ):
+    def __init__( self, file_name, struc_name ):
+        self.file_name = file_name
+        self.xyz = XYZTrajectoryFile( self.file_name, 'r' )
+        self.xyz_traj = self.xyz.read()
+        self.numframes = len(self.xyz_traj[0])
+        self.numatoms = len(self.xyz_traj[0][0])
+        self.x = None
+        self.box = np.zeros( ( 3, 3 ), dtype=np.float32 )
+        self.time = 0.0
+
+    def _get_frame( self, index ):
+        xyz = self.xyz_traj
+        self.x = xyz[index]
+        return self.box, self.x, self.time
+
+    def __del__( self ):
+        try:
+            self.xyz.close()
+        except:
+            pass
+
+
+class MDTrajTrajectory( Trajectory ):
+    def __init__( self, file_name, struc_path ):
+        self.file_name = file_name
+        self.struc_name = struc_path
+        filesize = os.path.getsize(self.file_name)
+        if filesize <= 1500000000:
+            self.frame =  md.load(self.file_name, top=self.struc_name)
+            self.numframes = self.frame.n_frames
+            self.numatoms = self.frame.n_atoms
+        else:
+            first_frame = md.load_frame(self.file_name, 0, self.struc_name)
+            times = 0
+            for chunk in md.iterload(self.file_name, top=self.struc_name, chunk=100, atom_indices=[1]):
+                times += chunk.n_frames
+            self.numframes = times
+            self.numatoms = first_frame.n_atoms
+            self.frame = None
+        self.x = None
+        self.box = np.zeros( ( 3, 3 ), dtype=np.float32 )
+        self.time = 0.0
+
+    def _get_frame( self, index ):
+        if self.frame:
+            frame = self.frame[index]
+        else:
+            frame = md.load_frame(self.file_name, index, self.struc_name)
+        try:
+            self.box = frame.unitcell_vectors * 10
+        except:
+            self.box = np.zeros( ( 3, 3 ), dtype=np.float32 )
+            pass
+        self.x = frame.xyz * 10
+        self.time = frame.time
+        return self.box, self.x, self.time
+

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup_args = {
     'install_requires': {
         "flask": ["flask"],
         "mdtraj": ["mdtraj"],
-        "mdanalysis;python_version<'3.4';platform_system!='Windows'": ["mdanalysis"],
+        "mdanalysis;platform_system!='Windows' and python_version<'3.4'": ["mdanalysis"],
         "simpletraj;platform_system!='Windows'": ["simpletraj"],
     },
     'packages': set(find_packages() + 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup_args = {
     'install_requires': {
         "flask": ["flask"],
         "mdtraj": ["mdtraj"],
-        #"simpletraj": ["simpletraj"],
+        "mdanalysis;python_version<'3.4';platform_system!='Windows'": ["mdanalysis"],
+        "simpletraj;platform_system!='Windows'": ["simpletraj"],
     },
     'packages': set(find_packages() + 
                 ['mdsrv']),

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup_args = {
     'install_requires': {
         "flask": ["flask"],
         "mdtraj": ["mdtraj"],
-        "simpletraj": ["simpletraj"],
+        #"simpletraj": ["simpletraj"],
     },
     'packages': set(find_packages() + 
                 ['mdsrv']),


### PR DESCRIPTION
- Windows support via MDTraj
- fast trajectory handling via MDAnalysis (currently only py2k)
- choose automatically mdtraj/MDAnalysis
- fixed travis & conda support
====
current supported trajectory file formats:
- both: .xtc, .trr, .dcd, .ncdf, .nc, .gro, .pdb, .xyz, .mdcrd
- only MDAnalysis (fast): .netcdf, .trz, .trj
- only MDTraj: .lammpstrj, .binpos, .h5, .dtr, .arc, .tng